### PR TITLE
fix error in wakatime.gd

### DIFF
--- a/addons/wakatime/wakatime.gd
+++ b/addons/wakatime/wakatime.gd
@@ -204,7 +204,7 @@ func clean_downloaded_files():
 
 
 func delete_file(path):
-	var dir = DirAccess.new()
+	var dir = DirAccess.open(path)
 	var error = dir.remove(path)
 	if error != OK:
 		pprint_error('Failed to remove %s' % path)


### PR DESCRIPTION
godot spits an error at you if you try to instantiate DirAcsess with .new() so changing it so diracses just opens the path is a pretty simple fix